### PR TITLE
feat!: use plain metadata values

### DIFF
--- a/lib/convertObjectToMetadata.js
+++ b/lib/convertObjectToMetadata.js
@@ -12,8 +12,7 @@ function convertObjectToMetadata(obj) {
   const metadata = new Metadata();
 
   Object.keys(obj).forEach((key) => {
-    const value = JSON.stringify(obj[key]);
-    metadata.set(key, value);
+    metadata.set(key, obj[key]);
   });
 
   return metadata;

--- a/lib/server/error/VerboseInternalGrpcError.js
+++ b/lib/server/error/VerboseInternalGrpcError.js
@@ -4,7 +4,7 @@ const InternalGrpcError = require('./InternalGrpcError');
 
 class VerboseInternalGrpcError extends InternalGrpcError {
   /**
-   *x
+   *
    * @param {InternalGrpcError} error
    */
   constructor(error) {

--- a/lib/server/error/VerboseInternalGrpcError.js
+++ b/lib/server/error/VerboseInternalGrpcError.js
@@ -1,8 +1,10 @@
+const cbor = require('cbor');
+
 const InternalGrpcError = require('./InternalGrpcError');
 
 class VerboseInternalGrpcError extends InternalGrpcError {
   /**
-   *
+   *x
    * @param {InternalGrpcError} error
    */
   constructor(error) {
@@ -16,7 +18,7 @@ class VerboseInternalGrpcError extends InternalGrpcError {
     const message = `${originalError.message} ${errorPath.trim()}`;
 
     const rawMetadata = error.getRawMetadata() || {};
-    rawMetadata.stack = originalError.stack;
+    rawMetadata['stack-bin'] = cbor.encode(originalError.stack);
 
     super(
       originalError,

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@cto.af/textdecoder": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@cto.af/textdecoder/-/textdecoder-0.0.0.tgz",
+      "integrity": "sha512-sJpx3F5xcVV/9jNYJQtvimo4Vfld/nD3ph+ZWtQzZ03Zo8rJC7QKQTRcIGS13Rcz80DwFNthCWMrd58vpY4ZAQ=="
+    },
     "@grpc/grpc-js": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.7.tgz",
@@ -431,6 +436,15 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "cbor": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-7.0.6.tgz",
+      "integrity": "sha512-rgt2RFogHGDLFU5r0kSfyeBc+de55DwYHP73KxKsQxsR5b0CYuQPH6AnJaXByiohpLdjQqj/K0SFcOV+dXdhSA==",
+      "requires": {
+        "@cto.af/textdecoder": "^0.0.0",
+        "nofilter": "^2.0.3"
+      }
     },
     "chai": {
       "version": "4.3.4",
@@ -2122,6 +2136,14 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
+      }
+    },
+    "nofilter": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-2.0.3.tgz",
+      "integrity": "sha512-FbuXC+lK+GU2+63D1kC1ETiZo+Z7SIi7B+mxKTCH1byrh6WFvfBCN/wpherFz0a0bjGd7EKTst/cz0yLeNngug==",
+      "requires": {
+        "@cto.af/textdecoder": "^0.0.0"
       }
     },
     "normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.3.6",
     "@grpc/proto-loader": "^0.5.2",
+    "cbor": "^7.0.6",
     "lodash.get": "^4.4.2",
     "protobufjs": "github:jawid-h/protobuf.js#8b91c72dca68fd6c418078fd2358c4969425dcdc",
     "semver": "^7.3.2"

--- a/test/integration/convertObjectToMetadata.spec.js
+++ b/test/integration/convertObjectToMetadata.spec.js
@@ -8,17 +8,17 @@ describe('convertObjectToMetadata', () => {
     const object = {
       some: 42,
       string: 'someString',
-      buffer: Buffer.from('some'),
+      'buffer-bin': Buffer.from('some'),
     };
 
     const result = convertObjectToMetadata(object);
 
     expect(result).to.be.an.instanceOf(Metadata);
     // eslint-disable-next-line no-underscore-dangle
-    expect(result.internalRepr.get('some')).to.deep.equal(['42']);
+    expect(result.internalRepr.get('some')).to.deep.equal([42]);
     // eslint-disable-next-line no-underscore-dangle
-    expect(result.internalRepr.get('string')).to.deep.equal(['"someString"']);
+    expect(result.internalRepr.get('string')).to.deep.equal(['someString']);
     // eslint-disable-next-line no-underscore-dangle
-    expect(result.internalRepr.get('buffer')).to.deep.equal(['{"type":"Buffer","data":[115,111,109,101]}']);
+    expect(result.internalRepr.get('buffer-bin')).to.deep.equal([Buffer.from('some')]);
   });
 });

--- a/test/unit/server/error/wrapInErrorHandlerFactory.spec.js
+++ b/test/unit/server/error/wrapInErrorHandlerFactory.spec.js
@@ -1,3 +1,5 @@
+const cbor = require('cbor');
+
 const wrapInErrorHandlerFactory = require('../../../../lib/server/error/wrapInErrorHandlerFactory');
 const InternalGrpcError = require('../../../../lib/server/error/InternalGrpcError');
 const VerboseInternalGrpcError = require('../../../../lib/server/error/VerboseInternalGrpcError');
@@ -90,9 +92,6 @@ describe('wrapInErrorHandlerFactory', () => {
       const [, errorPath] = someError.stack.toString().split(/\r\n|\n/);
 
       const errorMessage = `${someError.message} ${errorPath.trim()}`;
-      const metadata = {
-        stack: someError.stack,
-      };
 
       rpcMethod.throws(someError);
 
@@ -110,7 +109,9 @@ describe('wrapInErrorHandlerFactory', () => {
       expect(grpcError).to.be.instanceOf(VerboseInternalGrpcError);
       expect(grpcError.getError()).to.equal(someError);
       expect(grpcError.getMessage()).to.equal(errorMessage);
-      expect(grpcError.getRawMetadata()).to.deep.equal(metadata);
+      expect(grpcError.getRawMetadata()).to.deep.equal({
+        'stack-bin': cbor.encode(someError.stack),
+      });
 
       expect(loggerMock.error).to.be.calledOnceWith(someError);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use plain metadata values (string, number, binary) to remove decoding confusions

## What was done?
<!--- Describe your changes in detail -->
- Remove `JSON.stringfy` for metadata values

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Some metadata values can't be properly encoded and Metadata object throws errors

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
